### PR TITLE
Catch quit/exit exceptions in runGame()

### DIFF
--- a/main.t
+++ b/main.t
@@ -114,7 +114,13 @@ runGame(look)
     }
 
     /* run the main command loop until the game ends */
-    mainCommandLoop();
+    try {
+      mainCommandLoop();
+    } catch (QuittingException qe) {
+      // exit normally
+    } catch (EndOfFileException eofe) {
+      // exit normally
+    }
 }
 
 /* ------------------------------------------------------------------------ */


### PR DESCRIPTION
If exceptions are not caught, `showGoodbye()` is skipped.  `EndOfFileException` is thrown (in QTads, at least) if user types `Ctrl+W`, causing an "Unknown exception" to be printed.  By catching it here, it's treated as a clean exit of the game.