### PR TITLE
Fix warning about SymStairway when not using symconn

### DIFF
--- a/english/english.t
+++ b/english/english.t
@@ -2017,15 +2017,6 @@ DirState: State
         [&up, ['up', 'upward']], [&down, ['down', 'downward'] ],
         [&in, ['in', 'inner', 'inward']], [&out, ['out', 'outer', 'outward']]
     ]
-    
-    /* 
-     *   We exclude SymStairway because including 'up' or 'down' in its vocab confuses the parser's
-     *   interpretation of CLIMB UP and CLIMB DOWN.
-     */
-    appliesTo(obj)
-    {
-        return inherited(obj) && ! obj.ofKind(SymStairway);
-    }
 ;
 
 /*  

--- a/extensions/symconn.t
+++ b/extensions/symconn.t
@@ -208,6 +208,18 @@ modify Room
     }
 ;
 
+/* Modification to DirState for SymConn (symmetrical connector) extension */
+modify DirState    
+    /* 
+     *   We exclude SymStairway because including 'up' or 'down' in its vocab confuses the parser's
+     *   interpretation of CLIMB UP and CLIMB DOWN.
+     */
+    appliesTo(obj)
+    {
+        return inherited(obj) && ! obj.ofKind(SymStairway);
+    }
+;
+
 /* 
  *   Ensure that the vocab of any SymPassages located in the player character's starting location
  *   have the vocab appropriate to the side from which they're viewed.


### PR DESCRIPTION
This fix removes a warning saying that the symbol "SymStairway" was defined as an external reference but is not defined anywhere in the program. 

(This happens when not using the symconn extensions. )
