### PR TITLE
Make okaySetMsg available to subclasses

### DIFF
--- a/gadget.t
+++ b/gadget.t
@@ -205,8 +205,6 @@ class Settable: Thing
     invalidSettingMsg = BMsg(invalid setting, 'That {dummy} {is} not a valid
         setting for {the dobj}. ')
     
-    okaySetMsg =  BMsg(okay set, '{I} {set} {the dobj} to {1}. ', curSetting)
-    
     alreadySetMsg = BMsg(already set, '{The subj dobj} {is} already set to {1}.
         ', curSetting)
     

--- a/thing.t
+++ b/thing.t
@@ -7406,12 +7406,14 @@ class Thing:  ReplaceRedirector, Mentionable
         
         report()
         {
-            DMsg(okay set to, '{I} {set} {1} to {2}. ', gActionListStr, 
-                 curSetting); 
+            say(okaySetMsg);
         }
     }
        
     makeSetting(val) { curSetting = val; }
+    
+    okaySetMsg = BMsg(okay set to, '{I} {set} {1} to {2}. ', gActionListStr,
+        curSetting)
     
     cannotSetToMsg = BMsg(cannot set to, '{I} {cannot} set {that dobj} to
         anything. ')


### PR DESCRIPTION
Moves `okaySetMsg` from Settable to Thing, and modifies Thing to use it rather than a `DMsg` in SetTo `report()`.

This came about because I overrode Settable's `okaySetMsg` and saw it was not being printed in response to the command.  My first thought was to modify Settable's SetTo `report()` method to print it.

However, looking at the way SetTo is implemented in Thing, it appears to me that if it's DMsg in `report()` was simply made a single-quoted string in an `okaySetMsg` property, the problem is fixed for all subclasses, and not just Settable.

If there's a problem with this approach, let me know and I'll make whatever changes you think is needed.