### PR TITLE
Added a null check in MultiLoc's addToLocations to prevent an uniniti…

### DIFF
--- a/thing.t
+++ b/thing.t
@@ -10097,7 +10097,7 @@ class MultiLoc: object
          *   set the locationList to an empty list before attempting to build
          *   it.
          */
-        if(initialLocationList.length == 0)
+        if(initialLocationList == nil || initialLocationList.length == 0)
         {
             initialLocationList = locationList;
             locationList = [];               


### PR DESCRIPTION
Added a null check in MultiLoc's addToLocations() to prevent an uninitialized initalLocationList from throwing an exception.

The below sample code produces the null reference exception during game startup.

Because initialLocationList is not initialized by the game (and MultiLocScenery sets the internal location properties to nil) an exception happens as nightSky is initialized.

```
#charset "us-ascii"

#include <tads.h>
#include "advlite.h"

gameMain : GameMainDef
    initialPlayerChar = player
;

player : Player 'you'
    location = garden
;

nightSky : MultiLocScenery
    [
        [
            'moon; full', 
            'The moon illuminates the area. '
        ]
    ]
 
    initialLocationClass = OutdoorRoom
    notImportantMsg = delegated Distant
;

class OutdoorRoom : Room
;

garden : OutdoorRoom 'garden'
    "You are in the garden. "
;
```