### PR TITLE
Fix a typo in the specification of opposite directions

### DIFF
--- a/travel.t
+++ b/travel.t
@@ -2071,7 +2071,7 @@ northwestDir: CompassDirection
     name = BMsg(northwest, 'northwest')
     departureName = BMsg(depart northwest, 'to the northwest')
     sortingOrder = 1500
-    opposite = northeastDir
+    opposite = southeastDir
 ;
 
 southeastDir: CompassDirection


### PR DESCRIPTION
The opposite direction of northwest is southeast.